### PR TITLE
when searching all teams, show important info about teams

### DIFF
--- a/queries/teamsQueries.js
+++ b/queries/teamsQueries.js
@@ -1,7 +1,23 @@
 const db = require("../db/dbConfig");
 
 const getAllTeams = async () => {
-    return db.manyOrNone("SELECT * FROM teams")
+    return db.manyOrNone(`
+        SELECT 
+        teams.*,
+        json_build_object(
+            'id', owners.id,
+            'first_name', owners.first_name,
+            'last_name', owners.last_name,
+            'email', owners.email) 
+        AS owner,
+        COUNT(user_teams.user_id) AS total_members,
+        array_agg(user_teams.user_id) AS member_ids
+        FROM teams
+        JOIN users AS owners ON teams.owner_id = owners.id
+        JOIN user_teams ON teams.id = user_teams.team_id
+        GROUP BY teams.id, owners.id
+        ORDER BY teams.id DESC;
+`)
 }
 
 const getTeamsById = async (id) => {


### PR DESCRIPTION
Added sql code to teamQueries.
When all team data appears, it will show overall important information about each team. 
Made it easier to see team member id, info about owner and amount of users per team.
For example: 
{
      "id": 2,
      "owner_id": 1,
      "name": "Innovative Designs",
      "description": "Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.",
      "created_at": "2022-09-10T17:22:33.000Z",
      "owner": {
        "id": 1,
        "first_name": "John",
        "last_name": "Doe",
        "email": "john.doe@example.com"
      },
      "total_members": "2",
      "member_ids": [ 7, 8 ]
    }

